### PR TITLE
DP-798 Support Python 3.6 by removing dataclasses

### DIFF
--- a/origo/auth/credentials/client_credentials.py
+++ b/origo/auth/credentials/client_credentials.py
@@ -1,14 +1,22 @@
-from dataclasses import dataclass
-
 from keycloak.keycloak_openid import KeycloakOpenID
 
 from origo.auth.credentials.common import TokenProvider, TokenProviderNotInitialized
+from origo.config import Config
 
 
-@dataclass
 class ClientCredentialsProvider(TokenProvider):
     client_id: str = None
     client_secret: str = None
+
+    # TODO: Annotate the class with `@dataclass` and remove this once support
+    # for Python 3.6 is dropped.
+    def __init__(
+        self, config: Config, client_id: str = None, client_secret: str = None
+    ):
+        super().__init__(config)
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.__post_init__()
 
     def __post_init__(self):
         if not self.client_id:

--- a/origo/auth/credentials/common.py
+++ b/origo/auth/credentials/common.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from origo.config import Config
 
 
@@ -7,9 +5,13 @@ class TokenProviderNotInitialized(Exception):
     pass
 
 
-@dataclass
 class TokenProvider:
     config: Config
+
+    # TODO: Annotate the class with `@dataclass` and remove this once support
+    # for Python 3.6 is dropped.
+    def __init__(self, config: Config):
+        self.config = config
 
     def new_token(self):
         raise NotImplementedError

--- a/origo/auth/credentials/password_grant.py
+++ b/origo/auth/credentials/password_grant.py
@@ -1,17 +1,24 @@
 import logging
-from dataclasses import dataclass
 
 import requests
 
 from origo.auth.credentials.common import TokenProviderNotInitialized, TokenProvider
+from origo.config import Config
 
 log = logging.getLogger()
 
 
-@dataclass
 class TokenServiceProvider(TokenProvider):
     username: str = None
     password: str = None
+
+    # TODO: Annotate the class with `@dataclass` and remove this once support
+    # for Python 3.6 is dropped.
+    def __init__(self, config: Config, username: str = None, password: str = None):
+        super().__init__(config)
+        self.username = username
+        self.password = password
+        self.__post_init__()
 
     def __post_init__(self):
         self.token_service_url = self.config.config.get("tokenService")

--- a/origo/pipelines/resources/pipeline.py
+++ b/origo/pipelines/resources/pipeline.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 from typing import List
 
 from requests import HTTPError
@@ -9,7 +8,6 @@ from origo.pipelines.resources.pipeline_instance import PipelineInstance
 from origo.sdk import SDK
 
 
-@dataclass
 class Pipeline(PipelineBase):
     """A Pipeline resource in pipeline-api
 

--- a/origo/pipelines/resources/pipeline_base.py
+++ b/origo/pipelines/resources/pipeline_base.py
@@ -1,6 +1,5 @@
 import json
 import os
-from dataclasses import dataclass
 
 import jsonschema
 from jsonschema import ValidationError, SchemaError
@@ -17,7 +16,6 @@ class ResourceConflict(Exception):
     pass
 
 
-@dataclass
 class PipelineBase:
     """An abstract class for resources in pipeline-api
 

--- a/origo/pipelines/resources/pipeline_input.py
+++ b/origo/pipelines/resources/pipeline_input.py
@@ -1,6 +1,5 @@
 import json
 import os
-from dataclasses import dataclass
 
 import jsonschema
 from jsonschema import ValidationError, SchemaError
@@ -9,7 +8,6 @@ from origo.pipelines.resources.pipeline_base import PipelineBase, InternalError
 from origo.sdk import SDK
 
 
-@dataclass
 class PipelineInput(PipelineBase):
     """A Pipeline Input resource in pipeline-api
 

--- a/origo/pipelines/resources/pipeline_instance.py
+++ b/origo/pipelines/resources/pipeline_instance.py
@@ -1,12 +1,10 @@
 import json
-from dataclasses import dataclass
 
 from origo.pipelines.resources.pipeline_base import PipelineBase
 from origo.pipelines.resources.pipeline_input import PipelineInput
 from origo.sdk import SDK
 
 
-@dataclass
 class PipelineInstance(PipelineBase):
     """A Pipeline Instance resource in pipeline-api
 

--- a/origo/pipelines/resources/schema.py
+++ b/origo/pipelines/resources/schema.py
@@ -1,11 +1,9 @@
 import json
-from dataclasses import dataclass
 
 from origo.pipelines.resources.pipeline_base import PipelineBase
 from origo.sdk import SDK
 
 
-@dataclass
 class Schema(PipelineBase):
     """A Schema resource in pipeline-api
 

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,flake8,black
+envlist = py36,py37,flake8,black
 
 [testenv]
 deps=


### PR DESCRIPTION
Dataclasses were introduced in Python 3.7. To be able to support Python 3.6 in the SDK (as well as in Origo CLI later), the usage of dataclasses is removed. They can be restored when we drop support for Python 3.6, probably sometime after it has reached its end-of-life at 2021-12-23.

Seven dataclasses were defined in the codebase:

  `TokenProvider`
  `ClientCredentialsProvider(TokenProvider)`
  `TokenServiceProvider(TokenProvider)`

  `PipelineBase`
  `Pipeline(PipelineBase)`
  `PipelineInput(PipelineBase)`
  `Schema(PipelineBase)`

The three first classes, `TokenProvider`, `ClientCredentialsProvider`, and `TokenServiceProvider`, are trivially rewritten to normal classes with an `__init__` method similar to what a dataclass would generate. These changes should be simple to revert when dataclass usage is reintroduced again by deleting the custom `__init__` methods.

The remaining four classes, `PipelineBase`, `Pipeline`, `PipelineInput`, and `Schema`, didn't appear to actually use any dataclass-specific functionality. They defined their own `__init__` and `__repr__` methods, making the ones generated by `@dataclass` moot. These classes can probably be rewritten a bit to better leverage the advantages of dataclasses when dataclass usage is reintroduced.