### PR TITLE
Bump version: 0.2.1 → 0.2.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="origo-sdk-python",
-    version="0.2.1",
+    version="0.2.2",
     author="Oslo Origo",
     author_email="dataplattform@oslo.kommune.no",
     description="SDK for origo",


### PR DESCRIPTION
Release version 0.2.2 with support for Python 3.6.

Integration in Origo CLI is tested by hand and by running the "datasets boilerplate" command set.