### PR TITLE
DP-1598: Add optional retries parameter to sdk methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## ?.?.?
+## 0.5.3
 
 * Added `Dataset.get_distribution` method
 * Added `Dataset.update_*` methods for updating dataset, version, edition and distribution metadata
+* Added retry parameter to sdk methods
 
 ## 0.5.2
 

--- a/okdata/sdk/data/dataset.py
+++ b/okdata/sdk/data/dataset.py
@@ -11,18 +11,18 @@ class Dataset(SDK):
         self.__name__ = "dataset"
         super().__init__(config, auth, env)
 
-    def create_dataset(self, data=None):
+    def create_dataset(self, data=None, retries=0):
         url = self.config.get("datasetUrl")
         log.info(f"SDK:Creating dataset with payload: {data}")
-        result = self.post(url, data)
+        result = self.post(url, data, retries=retries)
         body = result.json()
         log.info(f"Created dataset: {body['Id']}")
         return body
 
-    def get_datasets(self, filter=None):
+    def get_datasets(self, filter=None, retries=0):
         url = self.config.get("datasetUrl")
         log.info(f"SDK:Get datasets from: {url}")
-        result = self.get(url)
+        result = self.get(url, retries=retries)
         ret = result.json()
         if filter is not None:
             if isinstance(filter, str):
@@ -33,11 +33,11 @@ class Dataset(SDK):
                 ret = tmp
         return ret
 
-    def get_dataset(self, datasetid):
+    def get_dataset(self, datasetid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}"
         log.info(f"SDK:Getting dataset: {datasetid} from: {url}")
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
     def update_dataset(self, datasetid, data):
         datasetUrl = self.config.get("datasetUrl")
@@ -48,30 +48,30 @@ class Dataset(SDK):
         log.info(f"Updated dataset: {body['Id']}")
         return body
 
-    def create_version(self, datasetid, data):
+    def create_version(self, datasetid, data, retries=0):
         baseUrl = self.config.get("datasetUrl")
         url = f"{baseUrl}/{datasetid}/versions"
         log.info(
             f"SDK:Creating version for: {datasetid} from: {url}, with payload: {data}"
         )
-        result = self.post(url, data)
+        result = self.post(url, data, retries=retries)
 
         body = result.json()
         datasetVersion = body["Id"].split("/")[1]
         log.info(f"SDK:Created dataset version: {datasetVersion}")
         return body
 
-    def get_versions(self, datasetid):
+    def get_versions(self, datasetid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions"
         log.info(f"SDK:Getting all dataset version for: {datasetid} from: {url}")
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
-    def get_latest_version(self, datasetid):
+    def get_latest_version(self, datasetid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/latest"
         log.info(f"SDK:Getting latest dataset version for: {datasetid} from: {url}")
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
     def update_version(self, datasetid, versionid, data):
         baseUrl = self.config.get("datasetUrl")
@@ -85,41 +85,42 @@ class Dataset(SDK):
         log.info(f"SDK:Updated dataset version: {datasetVersion} on {datasetid}")
         return body
 
-    def create_edition(self, datasetid, versionid, data):
+    def create_edition(self, datasetid, versionid, data, retries=0):
         baseUrl = self.config.get("datasetUrl")
         url = f"{baseUrl}/{datasetid}/versions/{versionid}/editions"
         log.info(
             f"SDK:Creating dataset edition for: {datasetid} from: {url} with payload: {data}"
         )
-        result = self.post(url, data)
+        result = self.post(url, data, retries=retries)
+        log.info(f"SDK:API reported back: {result.json()}")
         body = result.json()
         editionid = body["Id"].split("/")[2]
         log.info(f"SDK:Created dataset edition: {editionid} on {datasetid}/{versionid}")
         return body
 
-    def get_editions(self, datasetid, versionid):
+    def get_editions(self, datasetid, versionid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions"
         log.info(
             f"SDK:Getting version editions for: {datasetid}/{versionid} from: {url}"
         )
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
-    def get_edition(self, datasetid, versionid, editionid):
+    def get_edition(self, datasetid, versionid, editionid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}"
         log.info(
             f"SDK:Getting version edition for: {datasetid}/{versionid} from: {url}"
         )
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
-    def get_latest_edition(self, datasetid, versionid):
+    def get_latest_edition(self, datasetid, versionid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/latest"
         log.info(
             f"SDK:Getting latest dataset version edition for: {datasetid}/{versionid} from: {url}"
         )
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
     def update_edition(self, datasetid, versionid, editionid, data):
         baseUrl = self.config.get("datasetUrl")
@@ -133,9 +134,10 @@ class Dataset(SDK):
         log.info(f"SDK:Updated dataset edition: {editionid} on {datasetid}/{versionid}")
         return body
 
-    def get_distributions(self, datasetid, versionid, editionid):
+    def get_distributions(self, datasetid, versionid, editionid, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions"
+        return self.get(url, retries=retries).json()
         log.info(
             f"SDK:Getting distributions for: {datasetid}/{versionid}/{editionid} from: {url}"
         )
@@ -149,13 +151,13 @@ class Dataset(SDK):
         )
         return self.get(url).json()
 
-    def create_distribution(self, datasetid, versionid, editionid, data):
+    def create_distribution(self, datasetid, versionid, editionid, data, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions"
         log.info(
             f"SDK:Creating dataset distribution for: {datasetid} from: {url} with payload: {data}"
         )
-        result = self.post(url, data)
+        result = self.post(url, data, retries=retries)
         body = result.json()
         distributionid = body["Id"].split("/")[3]
         log.info(

--- a/okdata/sdk/data/dataset.py
+++ b/okdata/sdk/data/dataset.py
@@ -146,12 +146,12 @@ class Dataset(SDK):
     def get_distribution(
         self, datasetid, versionid, editionid, distributionid, retries=0
     ):
-        datasetUrl = self.config.get("datasetUrl", retries=retries)
+        datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions/{distributionid}"
         log.info(
             f"SDK:Getting distribution for: {datasetid}/{versionid}/{editionid} from: {url}"
         )
-        return self.get(url).json()
+        return self.get(url, retries=retries).json()
 
     def create_distribution(self, datasetid, versionid, editionid, data, retries=0):
         datasetUrl = self.config.get("datasetUrl")

--- a/okdata/sdk/data/dataset.py
+++ b/okdata/sdk/data/dataset.py
@@ -39,11 +39,11 @@ class Dataset(SDK):
         log.info(f"SDK:Getting dataset: {datasetid} from: {url}")
         return self.get(url, retries=retries).json()
 
-    def update_dataset(self, datasetid, data):
+    def update_dataset(self, datasetid, data, retries=0):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}"
         log.info(f"SDK:Updating dataset: {datasetid} with payload: {data}")
-        result = self.put(url, data)
+        result = self.put(url, data, retries=retries)
         body = result.json()
         log.info(f"Updated dataset: {body['Id']}")
         return body
@@ -73,13 +73,13 @@ class Dataset(SDK):
         log.info(f"SDK:Getting latest dataset version for: {datasetid} from: {url}")
         return self.get(url, retries=retries).json()
 
-    def update_version(self, datasetid, versionid, data):
+    def update_version(self, datasetid, versionid, data, retries=0):
         baseUrl = self.config.get("datasetUrl")
         url = f"{baseUrl}/{datasetid}/versions/{versionid}"
         log.info(
             f"SDK:Updating version {versionid} for: {datasetid} from: {url}, with payload: {data}"
         )
-        result = self.put(url, data)
+        result = self.put(url, data, retries=retries)
         body = result.json()
         datasetVersion = body["Id"].split("/")[1]
         log.info(f"SDK:Updated dataset version: {datasetVersion} on {datasetid}")
@@ -122,13 +122,13 @@ class Dataset(SDK):
         )
         return self.get(url, retries=retries).json()
 
-    def update_edition(self, datasetid, versionid, editionid, data):
+    def update_edition(self, datasetid, versionid, editionid, data, retries=0):
         baseUrl = self.config.get("datasetUrl")
         url = f"{baseUrl}/{datasetid}/versions/{versionid}/editions/{editionid}"
         log.info(
             f"SDK:Updating dataset edition {editionid} for: {datasetid} from: {url} with payload: {data}"
         )
-        result = self.put(url, data)
+        result = self.put(url, data, retries=retries)
         body = result.json()
         editionid = body["Id"].split("/")[2]
         log.info(f"SDK:Updated dataset edition: {editionid} on {datasetid}/{versionid}")
@@ -143,7 +143,9 @@ class Dataset(SDK):
         )
         return self.get(url).json()
 
-    def get_distribution(self, datasetid, versionid, editionid, distributionid):
+    def get_distribution(
+        self, datasetid, versionid, editionid, distributionid, retries=0
+    ):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions/{distributionid}"
         log.info(
@@ -166,14 +168,14 @@ class Dataset(SDK):
         return body
 
     def update_distribution(
-        self, datasetid, versionid, editionid, distributionid, data
+        self, datasetid, versionid, editionid, distributionid, data, retries=0
     ):
         datasetUrl = self.config.get("datasetUrl")
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions/{distributionid}"
         log.info(
             f"SDK:Updating distribution {distributionid} for: {datasetid} from: {url} with payload: {data}"
         )
-        result = self.put(url, data)
+        result = self.put(url, data, retries=retries)
         body = result.json()
         distributionid = body["Id"].split("/")[3]
         log.info(

--- a/okdata/sdk/data/dataset.py
+++ b/okdata/sdk/data/dataset.py
@@ -146,7 +146,7 @@ class Dataset(SDK):
     def get_distribution(
         self, datasetid, versionid, editionid, distributionid, retries=0
     ):
-        datasetUrl = self.config.get("datasetUrl")
+        datasetUrl = self.config.get("datasetUrl", retries=retries)
         url = f"{datasetUrl}/{datasetid}/versions/{versionid}/editions/{editionid}/distributions/{distributionid}"
         log.info(
             f"SDK:Getting distribution for: {datasetid}/{versionid}/{editionid} from: {url}"

--- a/okdata/sdk/data/download.py
+++ b/okdata/sdk/data/download.py
@@ -14,18 +14,18 @@ class Download(SDK):
         super().__init__(config, auth, env)
         self.data_exporter_url = self.config.get("dataExporterUrl")
 
-    def get_files(self, dataset_id, version, edition):
+    def get_files(self, dataset_id, version, edition, retries=0):
 
         get_download_urls_url = (
             f"{self.data_exporter_url}/{dataset_id}/{version}/{edition}"
         )
 
-        response = self.get(get_download_urls_url)
+        response = self.get(get_download_urls_url, retries=retries)
         return response.json()
 
-    def download(self, dataset_id, version, edition, output_path):
+    def download(self, dataset_id, version, edition, output_path, retries=0):
         downloaded_files = []
-        for file in self.get_files(dataset_id, version, edition):
+        for file in self.get_files(dataset_id, version, edition, retries=retries):
             file_name = file["key"].split("/")[-1]
             file_content_response = requests.get(file["url"])
             file_content_response.raise_for_status()

--- a/okdata/sdk/dataset_authorizer/simple_dataset_authorizer_client.py
+++ b/okdata/sdk/dataset_authorizer/simple_dataset_authorizer_client.py
@@ -1,5 +1,3 @@
-import requests
-
 from okdata.sdk import SDK
 
 
@@ -9,50 +7,59 @@ class SimpleDatasetAuthorizerClient(SDK):
         super().__init__(config, auth, env)
         self.dataset_authorizer_url = self.config.get("simpleDatasetAuthorizerUrl")
 
-    def create_dataset_access(self, dataset_id, prinical_id, bearer_token=None):
+    def create_dataset_access(
+        self, dataset_id, prinical_id, bearer_token=None, retries=0
+    ):
         create_dataset_access_url = f"{self.dataset_authorizer_url}/{dataset_id}"
         request_data = {"principalId": prinical_id}
         if bearer_token:
-            result = requests.post(
+            result = self.prepared_request_with_retries(retries).post(
                 create_dataset_access_url,
                 headers={"Authorization": f"Bearer {bearer_token}"},
                 data=request_data,
             )
             result.raise_for_status()
             return result.json()
-        return self.post(create_dataset_access_url, data=request_data).json()
+        return self.post(
+            create_dataset_access_url, data=request_data, retries=retries
+        ).json()
 
-    def check_dataset_access(self, dataset_id, bearer_token=None):
+    def check_dataset_access(self, dataset_id, bearer_token=None, retries=0):
         check_dataset_access_url = f"{self.dataset_authorizer_url}/{dataset_id}"
         if bearer_token:
-            result = requests.get(
+            result = self.prepared_request_with_retries(retries).get(
                 check_dataset_access_url,
                 headers={"Authorization": f"Bearer {bearer_token}"},
             )
             result.raise_for_status()
             return result.json()
-        return self.get(check_dataset_access_url).json()
+        return self.get(check_dataset_access_url, retries=retries).json()
 
-    def create_webhook_token(self, dataset_id, service_name):
+    def create_webhook_token(self, dataset_id, service_name, retries=0):
         response = self.post(
             f"{self.dataset_authorizer_url}/{dataset_id}/webhook",
             data={"service": service_name},
+            retries=retries,
         )
         return response.json()
 
-    def list_webhook_tokens(self, dataset_id):
-        response = self.get(f"{self.dataset_authorizer_url}/{dataset_id}/webhook")
-
-        return response.json()
-
-    def delete_webhook_token(self, dataset_id, webhook_token):
-        response = self.delete(
-            f"{self.dataset_authorizer_url}/{dataset_id}/webhook/{webhook_token}"
-        )
-        return response.json()
-
-    def authorize_webhook_token(self, dataset_id, webhook_token):
+    def list_webhook_tokens(self, dataset_id, retries=0):
         response = self.get(
-            f"{self.dataset_authorizer_url}/{dataset_id}/webhook/{webhook_token}/authorize"
+            f"{self.dataset_authorizer_url}/{dataset_id}/webhook", retries=retries
+        )
+
+        return response.json()
+
+    def delete_webhook_token(self, dataset_id, webhook_token, retries=0):
+        response = self.delete(
+            f"{self.dataset_authorizer_url}/{dataset_id}/webhook/{webhook_token}",
+            retries=retries,
+        )
+        return response.json()
+
+    def authorize_webhook_token(self, dataset_id, webhook_token, retries=0):
+        response = self.get(
+            f"{self.dataset_authorizer_url}/{dataset_id}/webhook/{webhook_token}/authorize",
+            retries=retries,
         )
         return response.json()

--- a/okdata/sdk/elasticsearch/queries.py
+++ b/okdata/sdk/elasticsearch/queries.py
@@ -11,9 +11,9 @@ class ElasticsearchQueries(SDK):
         super().__init__(config, auth, env)
         self.elasticsearch_query_url = self.config.get("elasticsearchQueryUrl")
 
-    def event_stat(self, dataset_id):
+    def event_stat(self, dataset_id, retries=0):
         url = f"{self.elasticsearch_query_url}/{dataset_id}/events"
-        res = self.get(url)
+        res = self.get(url, retries=retries)
         log.debug(f"event stat status: {res.status_code}")
 
         return res.json()

--- a/okdata/sdk/sdk.py
+++ b/okdata/sdk/sdk.py
@@ -66,7 +66,18 @@ class SDK(object):
     def prepared_request_with_retries(retries):
         #  https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#retry-on-failure
         retry_strategy = Retry(
-            total=retries, status_forcelist=[429, 500, 502, 503, 504]
+            total=retries,
+            status_forcelist=[429, 500, 502, 503, 504],
+            backoff_factor=1,
+            method_whitelist=[
+                "HEAD",
+                "GET",
+                "PUT",
+                "POST",
+                "DELETE",
+                "OPTIONS",
+                "TRACE",
+            ],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session = requests.Session()

--- a/okdata/sdk/sdk.py
+++ b/okdata/sdk/sdk.py
@@ -32,7 +32,7 @@ class SDK(object):
 
     def post(self, url, data, retries=0, **kwargs):
         log.info(f"SDK:Posting resource to url: {url}")
-        session = prepared_request_with_retries(retries)
+        session = self.prepared_request_with_retries(retries)
         result = session.post(
             url, data=json.dumps(data), headers=self.headers(), **kwargs
         )
@@ -41,7 +41,7 @@ class SDK(object):
 
     def put(self, url, data, retries=0, **kwargs):
         log.info(f"SDK:Putting resource to url: {url}")
-        session = prepared_request_with_retries(retries)
+        session = self.prepared_request_with_retries(retries)
         result = session.put(
             url, data=json.dumps(data), headers=self.headers(), **kwargs
         )
@@ -50,25 +50,27 @@ class SDK(object):
 
     def get(self, url, retries=0, **kwargs):
         log.info(f"SDK:Getting resource from url: {url}")
-        session = prepared_request_with_retries(retries)
+        session = self.prepared_request_with_retries(retries)
         result = session.get(url, headers=self.headers(), **kwargs)
         result.raise_for_status()
         return result
 
     def delete(self, url, retries=0, **kwargs):
         log.info(f"SDK:Deleting resource from url: {url}")
-        session = prepared_request_with_retries(retries)
+        session = self.prepared_request_with_retries(retries)
         result = session.delete(url, headers=self.headers(), **kwargs)
         result.raise_for_status()
         return result
 
+    @staticmethod
+    def prepared_request_with_retries(retries):
+        #  https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#retry-on-failure
+        retry_strategy = Retry(
+            total=retries, status_forcelist=[429, 500, 502, 503, 504]
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        session = requests.Session()
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
 
-def prepared_request_with_retries(retries):
-    #  https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#retry-on-failure
-    retry_strategy = Retry(total=retries, status_forcelist=[429, 500, 502, 503, 504])
-    adapter = HTTPAdapter(max_retries=retry_strategy)
-    session = requests.Session()
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-
-    return session
+        return session

--- a/okdata/sdk/status/status.py
+++ b/okdata/sdk/status/status.py
@@ -10,15 +10,15 @@ class Status(SDK):
         self.__name__ = "status"
         super().__init__(config, auth, env)
 
-    def get_status(self, uuid):
+    def get_status(self, uuid, retries=0):
         url = self.config.get("statusApiUrl")
         log.info(f"Retrieving status for UUID={uuid} from: {url}")
-        response = self.get(f"{url}/{uuid}")
+        response = self.get(f"{url}/{uuid}", retries=retries)
         if response.status_code == 200:
             return response.json()
         response.raise_for_status()
 
-    def update_status(self, trace_id, data):
+    def update_status(self, trace_id, data, retries=0):
         url = self.config.get("statusApiUrl")
-        response = self.post(f"{url}/{trace_id}", data)
+        response = self.post(f"{url}/{trace_id}", data, retries=retries)
         return response.json()

--- a/tests/data/upload_test.py
+++ b/tests/data/upload_test.py
@@ -6,9 +6,7 @@ from okdata.sdk.data.upload import Upload
 from okdata.sdk.auth.auth import Authenticate
 from okdata.sdk.config import Config
 from okdata.sdk.file_cache import FileCache
-from tests.auth.client_credentials_test_utils import (
-    default_test_client_credentials,
-)
+from tests.auth.client_credentials_test_utils import default_test_client_credentials
 
 
 config = Config()

--- a/tests/event/post_event_test.py
+++ b/tests/event/post_event_test.py
@@ -5,9 +5,7 @@ from okdata.sdk.event.post_event import PostEvent
 from okdata.sdk.auth.auth import Authenticate
 from okdata.sdk.config import Config
 from okdata.sdk.file_cache import FileCache
-from tests.auth.client_credentials_test_utils import (
-    default_test_client_credentials,
-)
+from tests.auth.client_credentials_test_utils import default_test_client_credentials
 
 config = Config()
 file_cache = FileCache(config)


### PR DESCRIPTION
Har bevisst ikke lagt til retries parameter for kall mot event-collector. Grunnen til det er at det i teorien kan oppstå en situasjon der event-collector feiler for kun enkelte av eventene som man sender inn via API-kall. Hvis man da kjører på med en retry på requesten så sender man potensielt inn duplikater.

Har også utelatt pipeline sdk kallene siden denne følger et veldig forskjellig mønster enn de andre sdk-ene.