### PR TITLE
Re-enable retries on low-level errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Added support for the new [permission API](https://github.com/oslokommune/okdata-permission-api).
 
+* Retries have been re-enabled for low-level network errors (connection errors,
+  read errors, and redirects). The `retry` parameter now only controls the
+  maximum number of retries to perform on bad HTTP status codes.
+
 ## 0.7.0
 
 * `Dataset.update_dataset` now supports partial metadata updates when the

--- a/okdata/sdk/sdk.py
+++ b/okdata/sdk/sdk.py
@@ -60,7 +60,7 @@ class SDK(object):
     def prepared_request_with_retries(retries):
         #  https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#retry-on-failure
         retry_strategy = Retry(
-            total=retries,
+            status=retries,
             status_forcelist=[429, 500, 502, 503, 504],
             backoff_factor=1,
             method_whitelist=[


### PR DESCRIPTION
Let the `retries` parameter only set the number of times to retry on bad HTTP status codes.

When overriding the `total` parameter to `urllib3.util.retry.Retry`, we were disabling lower-level retries built into urllib by defualt (connection error retries, read error retries, and redirects).