### PR TITLE
Add `types-requests` to mypy build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 skip_install = true
 deps =
   mypy
+  types-requests
   -rrequirements.txt
 commands =
   mypy -p okdata


### PR DESCRIPTION
Mypy no longer ships with third party modules as of version 0.900. Include `types-requests` in the mypy test build to avoid the error:

> Library stubs not installed for "requests" (or incompatible with Python 3.9)