### PR TITLE
DP-2253 Handle error response from status update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Handle error responses from status API update calls.
+
 ## 0.9.0
 
 * Tweaked the webhook client to create and authorize tokens based on operations

--- a/okdata/sdk/status/status.py
+++ b/okdata/sdk/status/status.py
@@ -12,13 +12,13 @@ class Status(SDK):
 
     def get_status(self, uuid, retries=0):
         url = self.config.get("statusApiUrl")
-        log.info(f"Retrieving status for UUID={uuid} from: {url}")
+        log.info(f"Retrieving status for UUID={uuid} from: {url}")
         response = self.get(f"{url}/{uuid}", retries=retries)
-        if response.status_code == 200:
-            return response.json()
         response.raise_for_status()
+        return response.json()
 
     def update_status(self, trace_id, data, retries=0):
         url = self.config.get("statusApiUrl")
         response = self.post(f"{url}/{trace_id}", data, retries=retries)
+        response.raise_for_status()
         return response.json()


### PR DESCRIPTION
Handle error responses from status API update calls by raising the appropriate `HTTPError` exception, instead of potentially failing during JSON decoding.