### PR TITLE
Make `make-clean` clean `.tox` too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -rf build
 	rm -rf dist
 	rm -rf *.egg-info
-
+	rm -rf .tox
 
 .PHONY: bump-patch
 bump-patch: is-git-clean


### PR DESCRIPTION
Clean the `.tox` directory too to ensure that the latest dependencies from `tox.ini` are installed when doing `make clean test` in the release creation workflow.