### PR TITLE
Unbreak tests by pinning `types-requests`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,17 @@ envlist = py36,py37,py38,py39,flake8,black,mypy
 
 [testenv]
 deps=
-  pytest
-  requests-mock==1.6.0
+  freezegun==0.3.12
+  pytest==6.2.5
   pytest-mock==1.12.1
   python-dateutil==2.8.0
-  freezegun==0.3.12
+  requests-mock==1.6.0
   -rrequirements.txt
 commands=
   pytest {posargs}
 setenv =
   OKDATA_CLIENT_ID = my-okdata-user
   OKDATA_CLIENT_SECRET = my-okdata-password
-
 
 [testenv:black]
 skip_install = true
@@ -34,7 +33,7 @@ commands =
 skip_install = true
 deps =
   mypy
-  types-requests
+  types-requests==2.25.12
   -rrequirements.txt
 commands =
   mypy -p okdata


### PR DESCRIPTION
Pin `types-requests` to match the major+minor version of `requests` that's in use to avoid sudden mypy errors.