### PR TITLE
T83 Use built-in JSON encoder from `requests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Use built-in JSON encoder from `requests` for `post`, `put` and `patch` methods.
+
 ## 0.9.1
 
 * Handle error responses from status API update calls.

--- a/okdata/sdk/sdk.py
+++ b/okdata/sdk/sdk.py
@@ -1,6 +1,5 @@
 import logging
 import requests
-import json
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -42,13 +41,13 @@ class SDK(object):
         return response
 
     def post(self, url, data, retries=0, **kwargs):
-        return self._request("post", url, retries, data=json.dumps(data), **kwargs)
+        return self._request("post", url, retries, json=data, **kwargs)
 
     def put(self, url, data, retries=0, **kwargs):
-        return self._request("put", url, retries, data=json.dumps(data), **kwargs)
+        return self._request("put", url, retries, json=data, **kwargs)
 
     def patch(self, url, data, retries=0, **kwargs):
-        return self._request("patch", url, retries, data=json.dumps(data), **kwargs)
+        return self._request("patch", url, retries, json=data, **kwargs)
 
     def get(self, url, retries=0, **kwargs):
         return self._request("get", url, retries, **kwargs)

--- a/tests/sdk_test.py
+++ b/tests/sdk_test.py
@@ -1,0 +1,17 @@
+from okdata.sdk import SDK
+
+
+def test_content_type(requests_mock):
+    client = SDK()
+    payload = {"foo": "bar"}
+    endpoint = "mock://api.com/foo"
+
+    for method in ["patch", "post", "put"]:
+        getattr(requests_mock, method)(endpoint)
+        getattr(client, method)(endpoint, payload)
+
+        req = requests_mock.last_request
+
+        assert "Content-Type" in req.headers
+        assert req.headers["Content-Type"] == "application/json"
+        assert req.json() == payload


### PR DESCRIPTION
Fixes request errors from APIs requiring `Content-Type=application/json`.