### PR TITLE
T#296 Add methods for updating teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * New parameter `include` added to `TeamClient.get_teams`.
 * New method `TeamClient.get_team_members` for getting the members of a team.
+* New methods `TeamClient.update_team_name` and
+  `TeamClient.update_team_attribute`.
 
 ## 2.1.0
 

--- a/okdata/sdk/team/client.py
+++ b/okdata/sdk/team/client.py
@@ -50,3 +50,18 @@ class TeamClient(SDK):
         url = "{}/teams/{}/members".format(self.api_url, quote(team_id))
         log.info(f"SDK:Getting team members from: {url}")
         return self.get(url).json()
+
+    def update_team_name(self, team_id, team_name):
+        """Update the name of team with ID `team_id` to `team_name`."""
+        url = "{}/teams/{}".format(self.api_url, quote(team_id))
+        log.info(f"SDK:Updating team name on: {url}")
+        return self.patch(url, {"name": team_name}).json()
+
+    def update_team_attribute(self, team_id, attribute, value):
+        """Update `attribute` of team with ID `team_id` to `value`.
+
+        Supplying a falsy `value` removes the attribute.
+        """
+        url = "{}/teams/{}".format(self.api_url, quote(team_id))
+        log.info(f"SDK:Updating team attribute on: {url}")
+        return self.patch(url, {"attributes": {attribute: [value]}}).json()

--- a/tests/team/test_client.py
+++ b/tests/team/test_client.py
@@ -52,3 +52,28 @@ def test_get_team_members(requests_mock):
         status_code=200,
     )
     assert TeamClient().get_team_members(team_id) == members
+
+
+def test_update_team_name(requests_mock):
+    team_id = "abc"
+    team_name = "Foo"
+    team = {"team_id": team_id, "name": team_name}
+    requests_mock.register_uri(
+        "PATCH",
+        re.compile(f"teams/{team_id}"),
+        text=json.dumps(team),
+        status_code=200,
+    )
+    assert TeamClient().update_team_name(team_id, team_name) == team
+
+
+def test_update_team_attribute(requests_mock):
+    team_id = "abc"
+    team = {"team_id": team_id, "name": "Foo", "attributes": {"a": ["b"]}}
+    requests_mock.register_uri(
+        "PATCH",
+        re.compile(f"teams/{team_id}"),
+        text=json.dumps(team),
+        status_code=200,
+    )
+    assert TeamClient().update_team_attribute(team_id, "a", "b") == team


### PR DESCRIPTION
Add methods to the team client for updating team names and attributes.

Depends on https://github.com/oslokommune/okdata-permission-api/pull/58.