### PR TITLE
Fix bug in `update_team_attribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Fixed a bug in `TeamClient.update_team_attribute` when `value` is falsy.
+
 ## 2.2.0
 
 * New parameter `include` added to `TeamClient.get_teams`.

--- a/okdata/sdk/team/client.py
+++ b/okdata/sdk/team/client.py
@@ -64,4 +64,6 @@ class TeamClient(SDK):
         """
         url = "{}/teams/{}".format(self.api_url, quote(team_id))
         log.info(f"SDK:Updating team attribute on: {url}")
-        return self.patch(url, {"attributes": {attribute: [value]}}).json()
+        return self.patch(
+            url, {"attributes": {attribute: [value] if value else []}}
+        ).json()


### PR DESCRIPTION
Fix a bug in `update_team_attribute` when `value` is falsy so that the attribute is cleared.