### PR TITLE
Add `Dataset.auto_create_edition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* New method `Dataset.auto_create_edition` for creating a new edition with an
+  automatic name based on the current time.
+
 ## 3.0.0
 
 * Added support for Python 3.12.

--- a/okdata/sdk/data/dataset.py
+++ b/okdata/sdk/data/dataset.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 
 from okdata.sdk import SDK
 
@@ -98,6 +99,20 @@ class Dataset(SDK):
         editionid = body["Id"].split("/")[2]
         log.info(f"SDK:Created dataset edition: {editionid} on {datasetid}/{versionid}")
         return body
+
+    def auto_create_edition(self, datasetid, versionid):
+        """Create an automatically named edition for the given dataset version.
+
+        Return the name of the newly created edition.
+        """
+        data = {
+            "edition": datetime.now().astimezone().replace(microsecond=0).isoformat(),
+            "description": f"Auto-created edition for {datasetid}/{versionid}",
+        }
+        log.info(f"Creating new edition for {datasetid}/{versionid} with data: {data}")
+        edition = self.create_edition(datasetid, versionid, data)
+        log.info(f"Created edition: {edition}")
+        return edition
 
     def get_editions(self, datasetid, versionid, retries=0):
         datasetUrl = self.config.get("datasetUrl")

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -163,6 +163,16 @@ class TestEdition:
         edition = ds.create_edition("test-dataset-createdataset-edition", 1, {})
         assert edition["Id"] == "test-dataset-createdataset-edition/1/test-edition"
 
+    def test_auto_create_edition(self, requests_mock):
+        ds = Dataset(config=config, auth=auth_default)
+        response = json.dumps({"Id": "test-dataset/1/test-edition"})
+        matcher = re.compile("datasets/test-dataset/versions/1/editions")
+        requests_mock.register_uri("POST", matcher, text=response, status_code=200)
+        assert (
+            ds.auto_create_edition("test-dataset", "1")["Id"]
+            == "test-dataset/1/test-edition"
+        )
+
     def test_getDatasetVersionEditions(self, requests_mock):
         ds = Dataset(config=config, auth=auth_default)
         response = json.dumps([{"Id": "test-dataset-get-dataset-version-editions"}])


### PR DESCRIPTION
Add a new method `Dataset.auto_create_edition` for creating a new edition with an automatic name based on the current time.

Based on a similarly named method in `okdata-cli`, but extracted here because it's useful in other cases in addition to the CLI. The CLI may in turn be changed to use this new method.